### PR TITLE
Create new response to return to intekenontvanger-backend.

### DIFF
--- a/src/main/java/generiek/api/EnrollmentEndpoint.java
+++ b/src/main/java/generiek/api/EnrollmentEndpoint.java
@@ -316,7 +316,7 @@ public class EnrollmentEndpoint {
         try {
             ResponseEntity exchanged = restTemplate.exchange(resultsURI, HttpMethod.POST, requestEntity, Void.class);
             LOG.debug(String.format("Received answer from %s with status %s", resultsURI, exchanged.getStatusCode()));
-            return exchanged;
+            return ResponseEntity.ok().body(exchanged.getBody());
         } catch (HttpStatusCodeException e) {
             return this.errorResponseEntity("Error from the OOAPI results endpoint for enrolment request:" + enrollmentRequest, e);
         }


### PR DESCRIPTION
Passing the resttemplate response causes error: 'Premature end of chunk coded message body: closing chunk expected'