### PR TITLE
Store the tokens after a refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Return error messages to broker (instead of whitelabel error pages)
 - Do not store the resultsendpoint, but save the homeinstitution and get the
 resultendpoint from service-registry when sending the sesult.
+- Store the access- and refreshtoken when refreshed
 
 ### Config changes
 

--- a/src/main/java/generiek/api/EnrollmentEndpoint.java
+++ b/src/main/java/generiek/api/EnrollmentEndpoint.java
@@ -299,6 +299,13 @@ public class EnrollmentEndpoint {
                     "Error in obtaining new accessToken with saved refreshToken for enrolment request:" + enrollmentRequest, e);
         }
         String accessToken = (String) oidcResponse.get("access_token");
+        String refreshToken = (String) oidcResponse.get("refresh_token");
+
+        //If all went well, save the new access token and refresh token in the enrollment request
+        enrollmentRequest.setAccessToken(accessToken);
+        enrollmentRequest.setRefreshToken(refreshToken);
+        enrollmentRepository.save(enrollmentRequest);
+
         String resultsURI;
         try {
             resultsURI = serviceRegistry.resultsURI(enrollmentRequest);


### PR DESCRIPTION
oidcng generates a new refresh-token when it's used to get a fresh access-token. Store this so we can send multiple results back to the home-institution.