### PR TITLE
Fix antMatchers /api/me

### DIFF
--- a/src/main/java/generiek/SecurityConfiguration.java
+++ b/src/main/java/generiek/SecurityConfiguration.java
@@ -69,7 +69,7 @@ public class SecurityConfiguration {
                             "/api/results",
                             "/associations/**",
                             "/api/play-results",
-                            "api/me",
+                            "/api/me",
                             "/person/**")
                     .and()
                     .csrf()


### PR DESCRIPTION
The endpoint `/api/me` is added to the `antMatchers` as `api/me`. This in turn implies that the endpoint `/api/me` will be not matched and therefore not protected.