### PR TITLE
Store access tokens in memory cache instead of persisting them in the database

### DIFF
--- a/docker/application.yml
+++ b/docker/application.yml
@@ -32,6 +32,12 @@ spring:
     # password: secret
   flyway:
     locations: classpath:db/{vendor}/migration
+  cache:
+    type: caffeine
+    cache-names:
+      - Tokens
+    caffeine:
+      spec: expireAfterWrite=15m,maximumSize=500
 
 config:
   connection_timeout_millis: 20_000

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,14 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,10 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/generiek/GenericApplication.java
+++ b/src/main/java/generiek/GenericApplication.java
@@ -2,9 +2,12 @@ package generiek;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class GenericApplication {
+    public static final String CacheName = "application";
 
     public static void main(String[] args) {
         SpringApplication.run(GenericApplication.class, args);

--- a/src/main/java/generiek/api/EnrollmentEndpoint.java
+++ b/src/main/java/generiek/api/EnrollmentEndpoint.java
@@ -1,9 +1,13 @@
 package generiek.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import generiek.LanguageFilter;
@@ -27,6 +31,7 @@ import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.oer.its.etsi102941.EnrolmentRequestMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
@@ -52,6 +57,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -85,6 +91,34 @@ public class EnrollmentEndpoint {
     private final ParameterizedTypeReference<Map<String, Object>> mapRef = new ParameterizedTypeReference<Map<String, Object>>() {
     };
     private final JWTValidator jwtValidator;
+
+    private final Cache<String, String> accessTokenCache = Caffeine.newBuilder()
+            .expireAfter(new Expiry<String, String>() {
+                @Override
+                public long expireAfterCreate(String key, String token, long currentTime) {
+                    try {
+                        JWTClaimsSet claims = JWTParser.parse(token).getJWTClaimsSet();
+                        long expSeconds = claims.getExpirationTime().toInstant().getEpochSecond();
+                        long nowSeconds = Instant.now().getEpochSecond();
+                        long secondsUntilExpiry =  Math.max(expSeconds - nowSeconds, 0);
+                        long cappedSeconds = Math.min(secondsUntilExpiry, 600); // max 10 min
+                        return TimeUnit.SECONDS.toNanos(cappedSeconds);
+                    } catch (Exception e) {
+                        return 0;
+                    }
+                }
+
+                @Override
+                public long expireAfterUpdate(String key, String token, long currentTime, long currentDuration) {
+                    return expireAfterCreate(key, token, currentTime);
+                }
+
+                @Override
+                public long expireAfterRead(String key, String token, long currentTime, long currentDuration) {
+                    return currentDuration;
+                }
+            })
+            .build();
 
     public EnrollmentEndpoint(@Value("${oidc.acr-context-class-ref}") String acr,
                               @Value("${oidc.client-id}") String clientId,
@@ -248,7 +282,7 @@ public class EnrollmentEndpoint {
         if (this.eduIDRequired) {
             enrollmentRequest.setEduid(eduid);
         }
-        enrollmentRequest.setAccessToken(accessToken);
+        accessTokenCache.put(enrollmentRequest.getIdentifier(), accessToken);
         enrollmentRequest.setRefreshToken(refreshToken);
         enrollmentRepository.save(enrollmentRequest);
 
@@ -690,9 +724,20 @@ public class EnrollmentEndpoint {
                                                                           HttpMethod httpMethod,
                                                                           boolean returnHttpStatusOk,
                                                                           boolean retry) {
+
+        var refreshAccessToken = !retry;
+        String accessToken = null;
+
+        try{
+            accessToken = resolveAccessToken(enrollmentRequest, refreshAccessToken);
+        } catch (HttpStatusCodeException e2) {
+            return this.errorResponseEntity("Error in obtaining new accessToken with saved refreshToken for enrolment request:" + enrollmentRequest, e2);
+        }
+
         HttpHeaders httpHeaders = getOidcAuthorizationHttpHeaders(
-                enrollmentRequest.getAccessToken(),
-                PersonAuthentication.HEADER.name());
+                accessToken,
+                PersonAuthentication.HEADER.name()
+        );
         HttpEntity<Map<String, Object>> requestEntity = new HttpEntity(body, httpHeaders);
 
         try {
@@ -704,12 +749,7 @@ public class EnrollmentEndpoint {
                     .body(exchanged.getBody());
         } catch (HttpStatusCodeException e) {
             if (retry) {
-                try {
-                    EnrollmentRequest refreshedEnrollmentRequest = refreshTokens(enrollmentRequest);
-                    return exchangeToHomeInstitution(refreshedEnrollmentRequest, body, uri, httpMethod, returnHttpStatusOk, false);
-                } catch (HttpStatusCodeException e2) {
-                    return this.errorResponseEntity("Error in obtaining new accessToken with saved refreshToken for enrolment request:" + enrollmentRequest, e2);
-                }
+                return exchangeToHomeInstitution(enrollmentRequest, body, uri, httpMethod, returnHttpStatusOk, false);
             } else {
                 return this.errorResponseEntity(String.format("Error %s from the OOAPI endpoint %s for enrolment request: %s.",
                         e.getStatusCode(),
@@ -717,28 +757,6 @@ public class EnrollmentEndpoint {
                         enrollmentRequest), e);
             }
         }
-    }
-
-    private EnrollmentRequest refreshTokens(EnrollmentRequest enrollmentRequest) {
-        LOG.debug("Obtaining new accessToken with saved refreshToken for enrolment request: " + enrollmentRequest);
-
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-        map.add("client_id", clientId);
-        map.add("client_secret", clientSecret);
-        map.add("grant_type", "refresh_token");
-        map.add("refresh_token", enrollmentRequest.getRefreshToken());
-
-        Map<String, Object> oidcResponse = tokenRequest(map);
-        String accessToken = (String) oidcResponse.get("access_token");
-        String refreshToken = (String) oidcResponse.get("refresh_token");
-
-        //If all went well, save the new access token and refresh token in the enrollment request
-        enrollmentRequest.setAccessToken(accessToken);
-        enrollmentRequest.setRefreshToken(refreshToken);
-
-        enrollmentRepository.save(enrollmentRequest);
-
-        return enrollmentRequest;
     }
 
     private ResponseEntity<Map<String, Object>> errorResponseEntity(String description, HttpStatusCodeException e) {
@@ -758,14 +776,14 @@ public class EnrollmentEndpoint {
 
     private Map<String, Object> person(EnrollmentRequest enrollmentRequest) {
         String personAuth = enrollmentRequest.getPersonAuth();
-        HttpHeaders httpHeaders = getOidcAuthorizationHttpHeaders(
-                enrollmentRequest.getAccessToken(), personAuth);
+        String accessToken = resolveAccessToken(enrollmentRequest);
+        HttpHeaders httpHeaders = getOidcAuthorizationHttpHeaders(accessToken, personAuth);
 
         LOG.debug("Retrieve person information from : " + enrollmentRequest.getPersonURI() + " using personAuth; " + personAuth);
 
         if (personAuth.equalsIgnoreCase(PersonAuthentication.FORM.name())) {
             MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("access_token", enrollmentRequest.getAccessToken());
+            map.add("access_token", accessToken);
             HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(map, httpHeaders);
             return restTemplate.exchange(enrollmentRequest.getPersonURI(), HttpMethod.POST, requestEntity, mapRef).getBody();
         } else {
@@ -827,4 +845,33 @@ public class EnrollmentEndpoint {
         }
     }
 
+    private String resolveAccessToken(EnrollmentRequest enrollmentRequest) {
+        return resolveAccessToken(enrollmentRequest, false);
+    }
+
+    private String resolveAccessToken(EnrollmentRequest enrollmentRequest, boolean forceRefresh){
+        if(forceRefresh){
+            accessTokenCache.invalidate(enrollmentRequest.getIdentifier());
+        }
+
+        return accessTokenCache.get(enrollmentRequest.getIdentifier(), key -> {
+            LOG.debug("Obtaining new accessToken with saved refreshToken for enrolment request: " + enrollmentRequest);
+
+            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+            map.add("client_id", clientId);
+            map.add("client_secret", clientSecret);
+            map.add("grant_type", "refresh_token");
+            map.add("refresh_token", enrollmentRequest.getRefreshToken());
+
+            Map<String, Object> oidcResponse = tokenRequest(map);
+            String accessToken = (String) oidcResponse.get("access_token");
+            String refreshToken = (String) oidcResponse.get("refresh_token");
+
+            enrollmentRequest.setRefreshToken(refreshToken);
+
+            enrollmentRepository.save(enrollmentRequest);
+
+            return accessToken;
+        });
+    }
 }

--- a/src/main/java/generiek/api/EnrollmentEndpoint.java
+++ b/src/main/java/generiek/api/EnrollmentEndpoint.java
@@ -1,13 +1,9 @@
 package generiek.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Expiry;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import generiek.LanguageFilter;
@@ -20,6 +16,7 @@ import generiek.model.PersonAuthentication;
 import generiek.ooapi.EnrollmentAssociation;
 import generiek.repository.AssociationRepository;
 import generiek.repository.EnrollmentRepository;
+import generiek.security.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -31,7 +28,6 @@ import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.bouncycastle.oer.its.etsi102941.EnrolmentRequestMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
@@ -57,10 +53,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.text.ParseException;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
@@ -91,34 +85,7 @@ public class EnrollmentEndpoint {
     private final ParameterizedTypeReference<Map<String, Object>> mapRef = new ParameterizedTypeReference<Map<String, Object>>() {
     };
     private final JWTValidator jwtValidator;
-
-    private final Cache<String, String> accessTokenCache = Caffeine.newBuilder()
-            .expireAfter(new Expiry<String, String>() {
-                @Override
-                public long expireAfterCreate(String key, String token, long currentTime) {
-                    try {
-                        JWTClaimsSet claims = JWTParser.parse(token).getJWTClaimsSet();
-                        long expSeconds = claims.getExpirationTime().toInstant().getEpochSecond();
-                        long nowSeconds = Instant.now().getEpochSecond();
-                        long secondsUntilExpiry =  Math.max(expSeconds - nowSeconds, 0);
-                        long cappedSeconds = Math.min(secondsUntilExpiry, 600); // max 10 min
-                        return TimeUnit.SECONDS.toNanos(cappedSeconds);
-                    } catch (Exception e) {
-                        return 0;
-                    }
-                }
-
-                @Override
-                public long expireAfterUpdate(String key, String token, long currentTime, long currentDuration) {
-                    return expireAfterCreate(key, token, currentTime);
-                }
-
-                @Override
-                public long expireAfterRead(String key, String token, long currentTime, long currentDuration) {
-                    return currentDuration;
-                }
-            })
-            .build();
+    private final TokenService tokenService;
 
     public EnrollmentEndpoint(@Value("${oidc.acr-context-class-ref}") String acr,
                               @Value("${oidc.client-id}") String clientId,
@@ -142,7 +109,8 @@ public class EnrollmentEndpoint {
                               EnrollmentRepository enrollmentRepository,
                               AssociationRepository associationRepository,
                               ServiceRegistry serviceRegistry,
-                              ObjectMapper objectMapper) throws MalformedURLException {
+                              ObjectMapper objectMapper,
+                              TokenService tokenService) throws MalformedURLException {
         this.acr = acr;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -158,6 +126,7 @@ public class EnrollmentEndpoint {
         this.associationRepository = associationRepository;
         this.serviceRegistry = serviceRegistry;
         this.objectMapper = objectMapper;
+        this.tokenService = tokenService;
         this.allowPlayground = allowPlayground;
         this.eduIDRequired = eduIDRequired;
         // Otherwise, we can't use method PATCH
@@ -282,7 +251,7 @@ public class EnrollmentEndpoint {
         if (this.eduIDRequired) {
             enrollmentRequest.setEduid(eduid);
         }
-        accessTokenCache.put(enrollmentRequest.getIdentifier(), accessToken);
+        tokenService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
         enrollmentRequest.setRefreshToken(refreshToken);
         enrollmentRepository.save(enrollmentRequest);
 
@@ -310,80 +279,80 @@ public class EnrollmentEndpoint {
     @Operation(summary = "Start Registration",
             description = "Triggers the actual registration at the guest institution using the student's data.")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
-        description = "The OOAPI v4 Offering object representing the course or component the student is enrolling in.",
-        required = true,
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON_VALUE,
-            examples = @ExampleObject(
-                name = "OOAPI v4 Offering Example",
-                summary = "A comprehensive OOAPI v4 Offering example",
-                value = "{\n" +
-                        "  \"offeringId\": \"123e4567-e89b-12d3-a456-134564174000\",\n" +
-                        "  \"offeringType\": \"component\",\n" +
-                        "  \"academicSession\": \"937983ad-cc0f-45a6-95ca-a8f60b7cf125\",\n" +
-                        "  \"name\": [{ \"language\": \"en-GB\", \"value\": \"Final written test for INFOMQNM\" }],\n" +
-                        "  \"abbreviation\": \"Test-INFOMQNM-20FS\",\n" +
-                        "  \"description\": [{ \"language\": \"en-GB\", \"value\": \"Research methods and statistics...\" }],\n" +
-                        "  \"teachingLanguage\": \"nld\",\n" +
-                        "  \"modeOfDelivery\": [ \"situated\" ],\n" +
-                        "  \"startDate\": \"2019-08-21\",\n" +
-                        "  \"endDate\": \"2023-06-15\",\n" +
-                        "  \"enrollStartDate\": \"2019-05-01\",\n" +
-                        "  \"enrollEndDate\": \"2019-08-01\",\n" +
-                        "  \"resultExpected\": true,\n" +
-                        "  \"resultValueType\": \"1-10\",\n" +
-                        "  \"organization\": \"452c1a86-a0af-475b-b03f-724878b0f387\"\n" +
-                        "}"
+            description = "The OOAPI v4 Offering object representing the course or component the student is enrolling in.",
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    examples = @ExampleObject(
+                            name = "OOAPI v4 Offering Example",
+                            summary = "A comprehensive OOAPI v4 Offering example",
+                            value = "{\n" +
+                                    "  \"offeringId\": \"123e4567-e89b-12d3-a456-134564174000\",\n" +
+                                    "  \"offeringType\": \"component\",\n" +
+                                    "  \"academicSession\": \"937983ad-cc0f-45a6-95ca-a8f60b7cf125\",\n" +
+                                    "  \"name\": [{ \"language\": \"en-GB\", \"value\": \"Final written test for INFOMQNM\" }],\n" +
+                                    "  \"abbreviation\": \"Test-INFOMQNM-20FS\",\n" +
+                                    "  \"description\": [{ \"language\": \"en-GB\", \"value\": \"Research methods and statistics...\" }],\n" +
+                                    "  \"teachingLanguage\": \"nld\",\n" +
+                                    "  \"modeOfDelivery\": [ \"situated\" ],\n" +
+                                    "  \"startDate\": \"2019-08-21\",\n" +
+                                    "  \"endDate\": \"2023-06-15\",\n" +
+                                    "  \"enrollStartDate\": \"2019-05-01\",\n" +
+                                    "  \"enrollEndDate\": \"2019-08-01\",\n" +
+                                    "  \"resultExpected\": true,\n" +
+                                    "  \"resultValueType\": \"1-10\",\n" +
+                                    "  \"organization\": \"452c1a86-a0af-475b-b03f-724878b0f387\"\n" +
+                                    "}"
+                    )
             )
-        )
     )
     @ApiResponses(value = {
-        @ApiResponse(
-            responseCode = "200", 
-            description = "Enrollment status (Success or Handled Error)",
-            content = @Content(
-                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                examples = {
-                    @ExampleObject(
-                        name = "Success Response",
-                        summary = "Enrollment successfully initiated",
-                        value = "{\n" +
-                                "  \"result\": \"ok\",\n" +
-                                "  \"code\": 200,\n" +
-                                "  \"message\": \"Your enrollment request has been received.\",\n" +
-                                "  \"oo-api-offering-id\": \"123e4567-e89b-12d3-a456-134564174000\",\n" +
-                                "  \"redirect\": \"https://optional.redirect/for-extra-information\"\n" +
-                                "}"
-                    ),
-                    @ExampleObject(
-                        name = "Handled Backend Error",
-                        summary = "Business error from SIS with support reference",
-                        value = "{\n" +
-                                "  \"result\": \"error\",\n" +
-                                "  \"code\": 400,\n" +
-                                "  \"message\": \"Student already registered for this component.\",\n" +
-                                "  \"reference\": \"REQ-af82-238d-1192\",\n" +
-                                "  \"oo-api-offering-id\": \"123e4567-e89b-12d3-a456-134564174000\"\n" +
-                                "}"
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Enrollment status (Success or Handled Error)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Success Response",
+                                            summary = "Enrollment successfully initiated",
+                                            value = "{\n" +
+                                                    "  \"result\": \"ok\",\n" +
+                                                    "  \"code\": 200,\n" +
+                                                    "  \"message\": \"Your enrollment request has been received.\",\n" +
+                                                    "  \"oo-api-offering-id\": \"123e4567-e89b-12d3-a456-134564174000\",\n" +
+                                                    "  \"redirect\": \"https://optional.redirect/for-extra-information\"\n" +
+                                                    "}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Handled Backend Error",
+                                            summary = "Business error from SIS with support reference",
+                                            value = "{\n" +
+                                                    "  \"result\": \"error\",\n" +
+                                                    "  \"code\": 400,\n" +
+                                                    "  \"message\": \"Student already registered for this component.\",\n" +
+                                                    "  \"reference\": \"REQ-af82-238d-1192\",\n" +
+                                                    "  \"oo-api-offering-id\": \"123e4567-e89b-12d3-a456-134564174000\"\n" +
+                                                    "}"
+                                    )
+                            }
                     )
-                }
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Technical connection failure",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Connection Exception",
+                                    summary = "Exception when communicating with the backend SIS",
+                                    value = "{\n" +
+                                            "  \"message\": \"Error in registration results for enrollmentRequest: ...\",\n" +
+                                            "  \"error\": \"Internal Server Error\"\n" +
+                                            "}"
+                            )
+                    )
             )
-        ),
-        @ApiResponse(
-            responseCode = "500", 
-            description = "Technical connection failure",
-            content = @Content(
-                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                examples = @ExampleObject(
-                    name = "Connection Exception",
-                    summary = "Exception when communicating with the backend SIS",
-                    value = "{\n" +
-                            "  \"message\": \"Error in registration results for enrollmentRequest: ...\",\n" +
-                            "  \"error\": \"Internal Server Error\"\n" +
-                            "}"
-                )
-            )
-        )
     })
     @PostMapping("/api/start")
     public ResponseEntity<Map<String, Object>> start(
@@ -728,8 +697,8 @@ public class EnrollmentEndpoint {
         var refreshAccessToken = !retry;
         String accessToken = null;
 
-        try{
-            accessToken = resolveAccessToken(enrollmentRequest, refreshAccessToken);
+        try {
+            accessToken = resolveEnrollmentRequestAccessToken(enrollmentRequest, refreshAccessToken);
         } catch (HttpStatusCodeException e2) {
             return this.errorResponseEntity("Error in obtaining new accessToken with saved refreshToken for enrolment request:" + enrollmentRequest, e2);
         }
@@ -776,7 +745,7 @@ public class EnrollmentEndpoint {
 
     private Map<String, Object> person(EnrollmentRequest enrollmentRequest) {
         String personAuth = enrollmentRequest.getPersonAuth();
-        String accessToken = resolveAccessToken(enrollmentRequest);
+        String accessToken = resolveEnrollmentRequestAccessToken(enrollmentRequest);
         HttpHeaders httpHeaders = getOidcAuthorizationHttpHeaders(accessToken, personAuth);
 
         LOG.debug("Retrieve person information from : " + enrollmentRequest.getPersonURI() + " using personAuth; " + personAuth);
@@ -808,9 +777,9 @@ public class EnrollmentEndpoint {
         String base64Enrollment = enrollmentRequest.serializeToBase64(objectMapper);
 
         List<ClaimsSetRequest.Entry> entries = Stream.of(
-                "family_name",
-                "given_name",
-                "eduid")
+                        "family_name",
+                        "given_name",
+                        "eduid")
                 .filter(claimValue -> this.eduIDRequired || !claimValue.equals("eduid"))
                 .map(ClaimsSetRequest.Entry::new)
                 .toList();
@@ -845,33 +814,34 @@ public class EnrollmentEndpoint {
         }
     }
 
-    private String resolveAccessToken(EnrollmentRequest enrollmentRequest) {
-        return resolveAccessToken(enrollmentRequest, false);
+    private String resolveEnrollmentRequestAccessToken(EnrollmentRequest enrollmentRequest) {
+        return resolveEnrollmentRequestAccessToken(enrollmentRequest, false);
     }
 
-    private String resolveAccessToken(EnrollmentRequest enrollmentRequest, boolean forceRefresh){
-        if(forceRefresh){
-            accessTokenCache.invalidate(enrollmentRequest.getIdentifier());
+    private String resolveEnrollmentRequestAccessToken(EnrollmentRequest enrollmentRequest, boolean forceRefresh) {
+        var accessToken = tokenService.getToken(enrollmentRequest.getIdentifier());
+
+        if (accessToken != null && !forceRefresh) {
+            return accessToken;
         }
 
-        return accessTokenCache.get(enrollmentRequest.getIdentifier(), key -> {
-            LOG.debug("Obtaining new accessToken with saved refreshToken for enrolment request: " + enrollmentRequest);
+        LOG.debug("Obtaining new accessToken with saved refreshToken for enrolment request: " + enrollmentRequest);
 
-            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("client_id", clientId);
-            map.add("client_secret", clientSecret);
-            map.add("grant_type", "refresh_token");
-            map.add("refresh_token", enrollmentRequest.getRefreshToken());
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("client_id", clientId);
+        map.add("client_secret", clientSecret);
+        map.add("grant_type", "refresh_token");
+        map.add("refresh_token", enrollmentRequest.getRefreshToken());
 
-            Map<String, Object> oidcResponse = tokenRequest(map);
-            String accessToken = (String) oidcResponse.get("access_token");
-            String refreshToken = (String) oidcResponse.get("refresh_token");
+        var oidcResponse = tokenRequest(map);
+        var refreshToken = (String) oidcResponse.get("refresh_token");
+        accessToken = (String) oidcResponse.get("access_token");
 
-            enrollmentRequest.setRefreshToken(refreshToken);
 
-            enrollmentRepository.save(enrollmentRequest);
+        tokenService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
+        enrollmentRequest.setRefreshToken(refreshToken);
+        enrollmentRepository.save(enrollmentRequest);
 
-            return accessToken;
-        });
+        return accessToken;
     }
 }

--- a/src/main/java/generiek/api/EnrollmentEndpoint.java
+++ b/src/main/java/generiek/api/EnrollmentEndpoint.java
@@ -16,7 +16,7 @@ import generiek.model.PersonAuthentication;
 import generiek.ooapi.EnrollmentAssociation;
 import generiek.repository.AssociationRepository;
 import generiek.repository.EnrollmentRepository;
-import generiek.security.TokenService;
+import generiek.security.TokenCacheService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -85,7 +85,7 @@ public class EnrollmentEndpoint {
     private final ParameterizedTypeReference<Map<String, Object>> mapRef = new ParameterizedTypeReference<Map<String, Object>>() {
     };
     private final JWTValidator jwtValidator;
-    private final TokenService tokenService;
+    private final TokenCacheService tokenCacheService;
 
     public EnrollmentEndpoint(@Value("${oidc.acr-context-class-ref}") String acr,
                               @Value("${oidc.client-id}") String clientId,
@@ -110,7 +110,7 @@ public class EnrollmentEndpoint {
                               AssociationRepository associationRepository,
                               ServiceRegistry serviceRegistry,
                               ObjectMapper objectMapper,
-                              TokenService tokenService) throws MalformedURLException {
+                              TokenCacheService tokenCacheService) throws MalformedURLException {
         this.acr = acr;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -126,7 +126,7 @@ public class EnrollmentEndpoint {
         this.associationRepository = associationRepository;
         this.serviceRegistry = serviceRegistry;
         this.objectMapper = objectMapper;
-        this.tokenService = tokenService;
+        this.tokenCacheService = tokenCacheService;
         this.allowPlayground = allowPlayground;
         this.eduIDRequired = eduIDRequired;
         // Otherwise, we can't use method PATCH
@@ -251,7 +251,7 @@ public class EnrollmentEndpoint {
         if (this.eduIDRequired) {
             enrollmentRequest.setEduid(eduid);
         }
-        tokenService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
+        tokenCacheService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
         enrollmentRequest.setRefreshToken(refreshToken);
         enrollmentRepository.save(enrollmentRequest);
 
@@ -819,7 +819,7 @@ public class EnrollmentEndpoint {
     }
 
     private String resolveEnrollmentRequestAccessToken(EnrollmentRequest enrollmentRequest, boolean forceRefresh) {
-        var accessToken = tokenService.getToken(enrollmentRequest.getIdentifier());
+        var accessToken = tokenCacheService.getToken(enrollmentRequest.getIdentifier());
 
         if (accessToken != null && !forceRefresh) {
             return accessToken;
@@ -838,7 +838,7 @@ public class EnrollmentEndpoint {
         accessToken = (String) oidcResponse.get("access_token");
 
 
-        tokenService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
+        tokenCacheService.saveToken(enrollmentRequest.getIdentifier(), accessToken);
         enrollmentRequest.setRefreshToken(refreshToken);
         enrollmentRepository.save(enrollmentRequest);
 

--- a/src/main/java/generiek/model/EnrollmentRequest.java
+++ b/src/main/java/generiek/model/EnrollmentRequest.java
@@ -58,9 +58,6 @@ public class EnrollmentRequest implements Serializable {
     private String eduid;
 
     @Column
-    private String accessToken;
-
-    @Column
     private String refreshToken;
 
     @Column
@@ -112,7 +109,6 @@ public class EnrollmentRequest implements Serializable {
                 ", personAuth=" + this.getPersonAuth() +
                 ", associations=" + this.getAssociations() +
                 ", eduid=" + this.getEduid() +
-                ", accessToken=" + StringUtils.hasText(this.getAccessToken()) +
                 ", refreshToken=" + StringUtils.hasText(this.getRefreshToken()) +
                 ", scope=" + this.getScope() +
                 ", created=" + this.getCreated() + ")";

--- a/src/main/java/generiek/security/TokenCacheItem.java
+++ b/src/main/java/generiek/security/TokenCacheItem.java
@@ -1,0 +1,22 @@
+package generiek.security;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+
+public class TokenCacheItem implements Serializable {
+    private final long expirationTimestamp;
+
+    @Getter
+    private final String token;
+
+    public TokenCacheItem(String token, long ttlInSeconds) {
+        this.token = token;
+        long maxTtlMillis = Math.min(ttlInSeconds, 15 * 60) * 1000;
+        this.expirationTimestamp = System.currentTimeMillis() + maxTtlMillis;
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() > expirationTimestamp;
+    }
+}

--- a/src/main/java/generiek/security/TokenCacheService.java
+++ b/src/main/java/generiek/security/TokenCacheService.java
@@ -1,21 +1,19 @@
 package generiek.security;
 
-import java.io.Serializable;
 import java.text.ParseException;
 import java.util.Objects;
 
-import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TokenService {
+public class TokenCacheService {
     private final CacheManager cacheManager;
 
     // Constructor injection is de Spring best practice
-    public TokenService(CacheManager cacheManager) {
+    public TokenCacheService(CacheManager cacheManager) {
         this.cacheManager = cacheManager;
     }
 

--- a/src/main/java/generiek/security/TokenService.java
+++ b/src/main/java/generiek/security/TokenService.java
@@ -1,0 +1,47 @@
+package generiek.security;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.util.Objects;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenService {
+    private final CacheManager cacheManager;
+
+    // Constructor injection is de Spring best practice
+    public TokenService(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    private Cache getRequiredCache() {
+        return Objects.requireNonNull(
+                cacheManager.getCache("Tokens"),
+                "Cache 'accessTokens' is not configured in the CacheManager!"
+        );
+    }
+
+    public void saveToken(String key, String accessToken) {
+        try {
+            var claims = JWTParser.parse(accessToken).getJWTClaimsSet();
+            var expSeconds = claims.getExpirationTime().toInstant().getEpochSecond();
+            var cacheItem = new TokenCacheItem(accessToken, expSeconds);
+            getRequiredCache().put(key, cacheItem);
+        } catch (ParseException e) {
+            throw new RuntimeException("Failed to parse jwt claims to inspect expiration time", e);
+        }
+    }
+
+    public String getToken(String key) {
+        var cacheItem = getRequiredCache().get(key, TokenCacheItem.class);
+
+        return cacheItem == null || cacheItem.isExpired()
+                ? null
+                : cacheItem.getToken();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,12 @@ spring:
     # password: secret
   flyway:
     locations: classpath:db/{vendor}/migration
+  cache:
+    type: caffeine
+    cache-names:
+      - Tokens
+    caffeine:
+      spec: expireAfterWrite=15m,maximumSize=500
 
 config:
   connection_timeout_millis: 20_000

--- a/src/main/resources/db/h2/migration/V6__drop_access_token.sql
+++ b/src/main/resources/db/h2/migration/V6__drop_access_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enrollment_requests DROP COLUMN access_token;

--- a/src/main/resources/db/mariadb/migration/V6__drop_access_token.sql
+++ b/src/main/resources/db/mariadb/migration/V6__drop_access_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enrollment_requests DROP COLUMN access_token;

--- a/src/main/resources/db/postgresql/migration/V6__drop_access_token.sql
+++ b/src/main/resources/db/postgresql/migration/V6__drop_access_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enrollment_requests DROP COLUMN access_token;

--- a/src/test/java/generiek/api/EnrollmentEndpointTest.java
+++ b/src/test/java/generiek/api/EnrollmentEndpointTest.java
@@ -254,7 +254,7 @@ public class EnrollmentEndpointTest extends AbstractIntegrationTest {
                 .withBody(objectMapper.writeValueAsString(singletonMap("associationsURI", "http://localhost:8081/associations")))));
 
         Map<String, String> tokenResult = new HashMap<>();
-        tokenResult.put("access_token", "123456");
+        tokenResult.put("access_token", "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImQ2MWEwZGJhODNkODZiZmNiOWFlY2I2MzEyNjU1NTI2In0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxNzgxMTcwNzg0fQ.w9obz51STU5XAoZre9TPpx2biXP7WzbE9Z12rDQ5VvwfOILkY8_LsVlCPERZCgfWfJaYoDjnGMVj640l05cGvg");
         tokenResult.put("refresh_token", "123456");
 
         stubFor(post(urlPathMatching("/oidc/token")).willReturn(aResponse()

--- a/src/test/java/generiek/api/EnrollmentEndpointTest.java
+++ b/src/test/java/generiek/api/EnrollmentEndpointTest.java
@@ -562,6 +562,43 @@ public class EnrollmentEndpointTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void accessTokenNotStoredInDatabaseAndNotRefetchedOnSubsequentCalls() throws Exception {
+        String state = doAuthorize(PersonAuthentication.HEADER.name());
+        String correlationId = doToken(state); // calls /oidc/token once
+
+        stubFor(post(urlPathMatching("/api/associations-uri")).willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBody(objectMapper.writeValueAsString(singletonMap("associationsURI", "http://localhost:8081/associations")))));
+        stubFor(post(urlPathMatching("/associations/external/me")).willReturn(aResponse()
+                .withStatus(201)
+                .withBody(readFile("data/association_me.json"))
+                .withHeader("Content-Type", "application/json")));
+
+        EnrollmentRequest enrollmentRequest = enrollmentRepository.findByIdentifier(correlationId).get();
+
+        // First call
+        given().when()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .auth().basic("sis", "secret")
+                .body(new HashMap<>())
+                .pathParam("personId", enrollmentRequest.getEduid())
+                .post("/associations/external/{personId}")
+                .then().statusCode(201);
+
+        // Second call — token must be reused, no extra fetch
+        given().when()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .auth().basic("sis", "secret")
+                .body(new HashMap<>())
+                .pathParam("personId", enrollmentRequest.getEduid())
+                .post("/associations/external/{personId}")
+                .then().statusCode(201);
+
+        // Token endpoint must have been called exactly once (during doToken, not during the two API calls)
+        verify(exactly(1), postRequestedFor(urlPathMatching("/oidc/token")));
+    }
+
+    @Test
     void registrationBrokerException() throws Exception {
         String state = doAuthorize(PersonAuthentication.HEADER.name());
         String correlationId = doToken(state);


### PR DESCRIPTION
Store access tokens in memory cache instead of persisting them in the database. This increases security in case the database is compromised, since an attacker would still need the application's client credentials to exchange refresh tokens for valid access tokens. Additionally, this enforces a proper audit trail because access tokens must be retrieved through the application flow.